### PR TITLE
BUGFIX: Account transactions crash

### DIFF
--- a/cmds.js
+++ b/cmds.js
@@ -216,7 +216,7 @@ function txns(cfg, args, op) {
 
     function show_txns_1(acc) {
         if(acc.name) op.out(op.chalk`{bold Transactions for Account:} {green ${acc.name}}`)
-        else op.out(op.chalk`{bold Transactions for Account:} {green ${ai.id}}`)
+        else op.out(op.chalk`{bold Transactions for Account:} {green ${acc.pub}}`)
         luminate.stellar.accountTransactions(cfg.horizon, acc, (err, txns) => {
             if(err) {
                 op.err(err)


### PR DESCRIPTION
Get transactions by using stellar public key(not wallet name) Luminate crashing.

To Reproduce Error:

- ` ./luminate txns GC6I32DOMFHYFHGUF6D72IEU27KP7CHDONMWAINHXCPIL6MQZAAARVER`